### PR TITLE
Add custom actions to the new action wizard

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-12-15T09:14:33.064Z\n"
-"PO-Revision-Date: 2021-12-15T09:14:33.064Z\n"
+"POT-Creation-Date: 2021-12-18T21:53:55.870Z\n"
+"PO-Revision-Date: 2021-12-18T21:53:55.870Z\n"
 
 msgid "Data values - Create/update"
 msgstr ""
@@ -267,6 +267,12 @@ msgstr ""
 msgid "List"
 msgstr ""
 
+msgid "Custom code"
+msgstr ""
+
+msgid "Custom Code"
+msgstr ""
+
 msgid "<No value>"
 msgstr ""
 
@@ -398,6 +404,9 @@ msgstr ""
 msgid "Configure pipeline"
 msgstr ""
 
+msgid "Custom Action"
+msgstr ""
+
 msgid "Actions"
 msgstr ""
 
@@ -457,6 +466,15 @@ msgid "Execute"
 msgstr ""
 
 msgid "Are you sure you want to delete {{total}} actions?"
+msgstr ""
+
+msgid "Choose action type"
+msgstr ""
+
+msgid "Standard action"
+msgstr ""
+
+msgid "Custom action"
 msgstr ""
 
 msgid "Actions are a way to trigger events in your application"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-12-15T09:11:24.323Z\n"
+"POT-Creation-Date: 2021-12-18T21:53:55.870Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -267,6 +267,12 @@ msgstr "Añadir"
 msgid "List"
 msgstr "Listar"
 
+msgid "Custom code"
+msgstr ""
+
+msgid "Custom Code"
+msgstr ""
+
 msgid "<No value>"
 msgstr ""
 
@@ -398,6 +404,9 @@ msgstr ""
 msgid "Configure pipeline"
 msgstr ""
 
+msgid "Custom Action"
+msgstr ""
+
 msgid "Actions"
 msgstr ""
 
@@ -457,6 +466,15 @@ msgid "Execute"
 msgstr ""
 
 msgid "Are you sure you want to delete {{total}} actions?"
+msgstr ""
+
+msgid "Choose action type"
+msgstr ""
+
+msgid "Standard action"
+msgstr ""
+
+msgid "Custom action"
 msgstr ""
 
 msgid "Actions are a way to trigger events in your application"

--- a/src/domain/entities/actions/SyncAction.ts
+++ b/src/domain/entities/actions/SyncAction.ts
@@ -4,9 +4,12 @@ import { ModelMapping } from "../mapping-template/MappingTemplate";
 import { DataSyncPeriod } from "../metadata/DataSyncPeriod";
 import { ModelValidation, validateModel, ValidationError } from "../Validations";
 
+export type ActionType = "standard" | "custom";
+
 export interface SyncActionData {
     id: string;
     name: string;
+    type: ActionType;
     description?: string;
     connectionId: string;
     period: DataSyncPeriod;
@@ -20,6 +23,7 @@ export interface SyncActionData {
 export class SyncAction implements SyncActionData {
     public readonly id: string;
     public readonly name: string;
+    public readonly type: ActionType;
     public readonly description?: string;
     public readonly connectionId: string;
     public readonly period: DataSyncPeriod;
@@ -32,6 +36,7 @@ export class SyncAction implements SyncActionData {
     constructor(data: SyncActionData) {
         this.id = data.id;
         this.name = data.name;
+        this.type = data.type;
         this.description = data.description;
         this.connectionId = data.connectionId;
         this.period = data.period;
@@ -68,6 +73,7 @@ export class SyncAction implements SyncActionData {
         return [
             { property: "name", validation: { type: "Standard", validation: "hasText" } },
             { property: "connectionId", validation: { type: "Standard", validation: "hasValue" } },
+            { property: "type", validation: { type: "Standard", validation: "hasText" } },
             { property: "period", validation: { type: "Standard", validation: "hasValue" } },
             { property: "orgUnitPaths", validation: { type: "Standard", validation: "hasItems" } },
             { property: "metadataIds", validation: { type: "Standard", validation: "hasItems" } },
@@ -108,6 +114,7 @@ export class SyncAction implements SyncActionData {
             name: "",
             description: "",
             connectionId: "",
+            type: "standard",
             period: "ALL",
             orgUnitPaths: [],
             metadataIds: [],
@@ -121,6 +128,7 @@ export class SyncAction implements SyncActionData {
             name: this.name,
             description: this.description,
             connectionId: this.connectionId,
+            type: this.type,
             period: this.period,
             startDate: this.startDate,
             endDate: this.endDate,

--- a/src/domain/entities/actions/SyncCustomAction.ts
+++ b/src/domain/entities/actions/SyncCustomAction.ts
@@ -1,0 +1,81 @@
+import { generateUid } from "../../../utils/uid";
+import { ModelValidation, validateModel, ValidationError } from "../Validations";
+import { ActionType } from "./SyncAction";
+export interface SyncCustomActionData {
+    id: string;
+    name: string;
+    type: ActionType;
+    description?: string;
+    connectionId: string;
+    customCode: string;
+}
+
+export class SyncCustomAction implements SyncCustomActionData {
+    public readonly id: string;
+    public readonly name: string;
+    public readonly type: ActionType;
+    public readonly description?: string;
+    public readonly connectionId: string;
+    public readonly customCode: string;
+
+
+    constructor(data: SyncCustomActionData) {
+        this.id = data.id;
+        this.name = data.name;
+        this.type = data.type;
+        this.description = data.description;
+        this.connectionId = data.connectionId;
+        this.customCode = data.customCode;
+
+    }
+
+    public validate(filter?: string[]): ValidationError[] {
+        return validateModel<SyncCustomAction>(this, this.moduleValidations()).filter(
+            ({ property }) => filter?.includes(property) ?? true
+        );
+    }
+
+    static build(data?: Partial<Pick<SyncCustomAction, keyof SyncCustomActionData>>): SyncCustomAction {
+        return new SyncCustomAction({ ...this.buildDefaultValues(), ...data });
+    }
+
+    public update(data?: Partial<Pick<SyncCustomAction, keyof SyncCustomActionData>>): SyncCustomAction {
+        return SyncCustomAction.build({ ...this, ...data });
+    }
+
+    private moduleValidations(): ModelValidation[] {
+        return [
+            { property: "name", validation: { type: "Standard", validation: "hasText" } },
+            { property: "connectionId", validation: { type: "Standard", validation: "hasValue" } },
+            { property: "customCode", validation: { type: "Standard", validation: "hasValue" } },
+            { property: "type", validation: { type: "Standard", validation: "hasText" } },
+
+        ];
+    }
+
+    protected static buildDefaultValues = (): Pick<SyncCustomAction, keyof SyncCustomActionData> => {
+        const template = `async function execute(martRepository: XMartRepository, instanceRepository: InstanceRepository): Promise<any> {
+    
+        }
+        `;
+        return {
+            id: generateUid(),
+            name: "",
+            description: "",
+            type: "custom",
+            connectionId: "",
+            customCode: template
+        };
+    };
+
+    public toData(): SyncCustomActionData {
+        return {
+            id: this.id,
+            name: this.name,
+            type: this.type,
+            description: this.description,
+            connectionId: this.connectionId,
+            customCode: this.customCode
+        };
+    }
+}

--- a/src/domain/entities/actions/SyncCustomAction.ts
+++ b/src/domain/entities/actions/SyncCustomAction.ts
@@ -18,7 +18,6 @@ export class SyncCustomAction implements SyncCustomActionData {
     public readonly connectionId: string;
     public readonly customCode: string;
 
-
     constructor(data: SyncCustomActionData) {
         this.id = data.id;
         this.name = data.name;
@@ -26,7 +25,6 @@ export class SyncCustomAction implements SyncCustomActionData {
         this.description = data.description;
         this.connectionId = data.connectionId;
         this.customCode = data.customCode;
-
     }
 
     public validate(filter?: string[]): ValidationError[] {
@@ -49,7 +47,6 @@ export class SyncCustomAction implements SyncCustomActionData {
             { property: "connectionId", validation: { type: "Standard", validation: "hasValue" } },
             { property: "customCode", validation: { type: "Standard", validation: "hasValue" } },
             { property: "type", validation: { type: "Standard", validation: "hasText" } },
-
         ];
     }
 
@@ -64,7 +61,7 @@ export class SyncCustomAction implements SyncCustomActionData {
             description: "",
             type: "custom",
             connectionId: "",
-            customCode: template
+            customCode: template,
         };
     };
 
@@ -75,7 +72,7 @@ export class SyncCustomAction implements SyncCustomActionData {
             type: this.type,
             description: this.description,
             connectionId: this.connectionId,
-            customCode: this.customCode
+            customCode: this.customCode,
         };
     }
 }

--- a/src/domain/repositories/ActionRepository.ts
+++ b/src/domain/repositories/ActionRepository.ts
@@ -1,9 +1,10 @@
 import { FutureData } from "../entities/Future";
 import { SyncAction } from "../entities/actions/SyncAction";
+import { SyncCustomAction } from "../entities/actions/SyncCustomAction";
 
 export interface ActionRepository {
     getById(id: string): FutureData<SyncAction>;
     list(): FutureData<SyncAction[]>;
-    save(rules: SyncAction): FutureData<void>;
+    save(rules: SyncAction | SyncCustomAction): FutureData<void>;
     delete(ids: string[]): FutureData<void>;
 }

--- a/src/domain/usecases/actions/SaveActionsUseCase.ts
+++ b/src/domain/usecases/actions/SaveActionsUseCase.ts
@@ -29,28 +29,26 @@ export class SaveActionUseCase implements UseCase {
     ) {}
 
     public execute(action: SyncAction | SyncCustomAction): FutureData<void> {
-        const isCustomAction = _.has(action, 'customCode');
+        const isCustomAction = _.has(action, "customCode");
 
-        if(isCustomAction) {
+        if (isCustomAction) {
             return this.actionRepository.save(action);
-        }
-        else {
+        } else {
             return this.validateModelMappings(action as SyncAction)
-            .flatMap(action =>
-                Future.joinObj({
-                    saveResult: this.actionRepository.save(action),
-                    dataMart: this.connectionsRepository.getById(action.connectionId),
-                })
-            )
-            .flatMap(({ dataMart }) => this.loadModelsInXMart(dataMart, action as SyncAction))
-            .flatMap(() => Future.success(undefined))
-            .flatMapError(error => {
-                return Future.error(
-                    i18n.t(`An error has occurred saving the action:\n{{error}}`, { error, nsSeparator: false })
-                );
-            });
+                .flatMap(action =>
+                    Future.joinObj({
+                        saveResult: this.actionRepository.save(action),
+                        dataMart: this.connectionsRepository.getById(action.connectionId),
+                    })
+                )
+                .flatMap(({ dataMart }) => this.loadModelsInXMart(dataMart, action as SyncAction))
+                .flatMap(() => Future.success(undefined))
+                .flatMapError(error => {
+                    return Future.error(
+                        i18n.t(`An error has occurred saving the action:\n{{error}}`, { error, nsSeparator: false })
+                    );
+                });
         }
-        
     }
 
     validateModelMappings(action: SyncAction): FutureData<SyncAction> {

--- a/src/webapp/components/action-wizard/ActionWizard.tsx
+++ b/src/webapp/components/action-wizard/ActionWizard.tsx
@@ -3,7 +3,6 @@ import _ from "lodash";
 import React from "react";
 import { useLocation } from "react-router-dom";
 import { SyncAction } from "../../../domain/entities/actions/SyncAction";
-
 import i18n from "../../../locales";
 import { GeneralInfoStep } from "./steps/GeneralInfoStep";
 import { MappingSelectionStep } from "./steps/MappingSelectionStep";

--- a/src/webapp/components/custom-action-wizard/CustomActionWizard.tsx
+++ b/src/webapp/components/custom-action-wizard/CustomActionWizard.tsx
@@ -2,24 +2,21 @@ import { Wizard, WizardStep } from "@eyeseetea/d2-ui-components";
 import _ from "lodash";
 import React from "react";
 import { useLocation } from "react-router-dom";
-import { SyncAction } from "../../../domain/entities/actions/SyncAction";
+import { SyncCustomAction } from "../../../domain/entities/actions/SyncCustomAction";
 
 import i18n from "../../../locales";
 import { GeneralInfoStep } from "./steps/GeneralInfoStep";
-import { MappingSelectionStep } from "./steps/MappingSelectionStep";
-import { MetadataSelectionStep } from "./steps/MetadataSelectionStep";
-import { OrganisationUnitsSelectionStep } from "./steps/OrganisationUnitsSelectionStep";
-import { PeriodSelectionStep } from "./steps/PeriodSelectionStep";
 import { SummaryStep } from "./steps/SummaryStep";
+import { CustomCodeStep } from "./steps/CustomCodeStep";
 
-interface ActionWizardProps {
-    action: SyncAction;
+interface CustomActionWizardProps {
+    action: SyncCustomAction;
     isDialog?: boolean;
-    onChange?(action: SyncAction): void;
+    onChange?(action: SyncCustomAction): void;
     onCancel?(): void;
 }
 
-export const stepsBaseInfo: ActionWizardStep[] = [
+export const stepsBaseInfo: CustomActionWizardStep[] = [
     {
         key: "general-info",
         label: i18n.t("General info"),
@@ -27,28 +24,10 @@ export const stepsBaseInfo: ActionWizardStep[] = [
         validationKeys: ["name", "connectionId"],
     },
     {
-        key: "organisations-units",
-        label: i18n.t("Organisation units"),
-        component: OrganisationUnitsSelectionStep,
-        validationKeys: ["orgUnitPaths"],
-    },
-    {
-        key: "metadata",
-        label: i18n.t("Metadata"),
-        component: MetadataSelectionStep,
-        validationKeys: ["metadataIds"],
-    },
-    {
-        key: "period",
-        label: i18n.t("Period"),
-        component: PeriodSelectionStep,
-        validationKeys: ["startDate", "endDate"],
-    },
-    {
-        key: "mapping",
-        label: i18n.t("Mapping"),
-        component: MappingSelectionStep,
-        validationKeys: ["modelMappings"],
+        key: "custom-code",
+        label: i18n.t("Custom code"),
+        component: CustomCodeStep,
+        validationKeys: [],
     },
     {
         key: "summary",
@@ -57,19 +36,18 @@ export const stepsBaseInfo: ActionWizardStep[] = [
         validationKeys: [],
     },
 ];
-
-export interface ActionWizardStep extends WizardStep {
+export interface CustomActionWizardStep extends WizardStep {
     validationKeys: string[];
-    hidden?: (action: SyncAction) => boolean;
+    hidden?: (action: SyncCustomAction) => boolean;
 }
 
-export interface ActionWizardStepProps {
-    action: SyncAction;
-    onChange: (action: SyncAction) => void;
+export interface CustomActionWizardStepProps {
+    action: SyncCustomAction;
+    onChange: (action: SyncCustomAction) => void;
     onCancel: () => void;
 }
 
-const ActionWizard: React.FC<ActionWizardProps> = ({ action, onCancel, onChange }) => {
+const CustomActionWizard: React.FC<CustomActionWizardProps> = ({ action, onCancel, onChange }) => {
     const location = useLocation();
     const steps = stepsBaseInfo.map(step => ({ ...step, props: { action, onCancel, onChange } }));
 
@@ -98,4 +76,4 @@ const ActionWizard: React.FC<ActionWizardProps> = ({ action, onCancel, onChange 
     );
 };
 
-export default ActionWizard;
+export default CustomActionWizard;

--- a/src/webapp/components/custom-action-wizard/steps/CustomCodeStep.tsx
+++ b/src/webapp/components/custom-action-wizard/steps/CustomCodeStep.tsx
@@ -1,0 +1,35 @@
+import Editor, { Monaco } from "@monaco-editor/react";
+import React from "react";
+import { actionGlobals } from "../../../../data/utils/action-types";
+import { CustomActionWizardStepProps } from "../CustomActionWizard";
+
+export const CustomCodeStep = ({ action, onChange }: CustomActionWizardStepProps) => {
+    const onChangeField = (value: string | undefined) => onChange(action.update({ customCode: value }));
+
+    return (
+        <React.Fragment>
+            <MonacoEditor value={action.customCode} onChange={onChangeField} />
+        </React.Fragment>
+    );
+};
+
+
+const MonacoEditor: React.FC<{ value: string; onChange: (value: string | undefined) => void }> = ({
+    value,
+    onChange,
+}) => {
+    const handleEditorDidMount = (monaco: Monaco) => {
+        monaco.languages.typescript.typescriptDefaults.addExtraLib(actionGlobals, "globals.d.ts");
+    };
+
+    return (
+        <Editor
+            height="40vh"
+            defaultLanguage="typescript"
+            onChange={onChange}
+            value={value}
+            options={{ minimap: { enabled: false } }}
+            beforeMount={handleEditorDidMount}
+        />
+    );
+};

--- a/src/webapp/components/custom-action-wizard/steps/CustomCodeStep.tsx
+++ b/src/webapp/components/custom-action-wizard/steps/CustomCodeStep.tsx
@@ -13,7 +13,6 @@ export const CustomCodeStep = ({ action, onChange }: CustomActionWizardStepProps
     );
 };
 
-
 const MonacoEditor: React.FC<{ value: string; onChange: (value: string | undefined) => void }> = ({
     value,
     onChange,

--- a/src/webapp/components/custom-action-wizard/steps/GeneralInfoStep.tsx
+++ b/src/webapp/components/custom-action-wizard/steps/GeneralInfoStep.tsx
@@ -1,0 +1,87 @@
+import { useSnackbar } from "@eyeseetea/d2-ui-components";
+import { TextField } from "@material-ui/core";
+import React, { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+import { SyncCustomAction } from "../../../../domain/entities/actions/SyncCustomAction";
+import { DataMart } from "../../../../domain/entities/xmart/DataMart";
+import i18n from "../../../../locales";
+import { Dictionary } from "../../../../types/utils";
+import { useAppContext } from "../../../contexts/app-context";
+import Dropdown from "../../dropdown/Dropdown";
+import { CustomActionWizardStepProps } from "../CustomActionWizard";
+
+export const GeneralInfoStep = ({ action, onChange }: CustomActionWizardStepProps) => {
+    const [connections, setConnections] = useState<DataMart[]>([]);
+    const [errors, setErrors] = useState<Dictionary<string>>({});
+    const { compositionRoot } = useAppContext();
+    const snackbar = useSnackbar();
+
+    const onChangeField = useCallback(
+        (field: keyof SyncCustomAction) => {
+            return (event: React.ChangeEvent<{ value: unknown }>) => {
+                const newAction = action.update({ [field]: event.target.value });
+                const messages = newAction.validate(["name"]).map(e => e.description);
+                setErrors(errors => ({ ...errors, [field]: messages.join("\n") }));
+                onChange(newAction);
+            };
+        },
+        [action, onChange]
+    );
+
+    useEffect(() => {
+        compositionRoot.connection.listAll().run(
+            dataMarts => setConnections(dataMarts),
+            error => snackbar.error(error)
+        );
+    }, [compositionRoot, snackbar]);
+
+    const onChangeConnection = useCallback(
+        (connectionId?: string) => {
+            onChange(action.update({ connectionId }));
+        },
+        [action, onChange]
+    );
+
+    return (
+        <React.Fragment>
+            <Row>
+                <TextField
+                    fullWidth={true}
+                    label={i18n.t("Name (*)")}
+                    value={action.name ?? ""}
+                    onChange={onChangeField("name")}
+                    error={!!errors["name"]}
+                    helperText={errors["name"]}
+                />
+            </Row>
+
+            <Row>
+                <Dropdown
+                    items={connections}
+                    value={action.connectionId ?? connections[0]?.id ?? ""}
+                    onValueChange={onChangeConnection}
+                    label={i18n.t("Connection")}
+                    hideEmpty={true}
+                    view={"full-width"}
+                />
+            </Row>
+
+            <Row>
+                <TextField
+                    fullWidth={true}
+                    multiline={true}
+                    rows={4}
+                    label={i18n.t("Description")}
+                    value={action.description ?? ""}
+                    onChange={onChangeField("description")}
+                    error={!!errors["description"]}
+                    helperText={errors["description"]}
+                />
+            </Row>
+        </React.Fragment>
+    );
+};
+
+const Row = styled.div`
+    margin-bottom: 25px;
+`;

--- a/src/webapp/components/custom-action-wizard/steps/SummaryStep.tsx
+++ b/src/webapp/components/custom-action-wizard/steps/SummaryStep.tsx
@@ -116,7 +116,7 @@ const SummaryStepContent: React.FC<SummaryStepContentProps> = ({ action }) => {
 
             <LiEntry label={i18n.t("Connection")} value={connection?.name} />
 
-            {action.description && <LiEntry label={i18n.t("Description")} value={action.description} /> }
+            {action.description && <LiEntry label={i18n.t("Description")} value={action.description} />}
 
             <LiEntry label={i18n.t("Custom Code")} value={action.customCode} />
         </ul>

--- a/src/webapp/components/custom-action-wizard/steps/SummaryStep.tsx
+++ b/src/webapp/components/custom-action-wizard/steps/SummaryStep.tsx
@@ -1,0 +1,124 @@
+import { ConfirmationDialog, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import { Button, makeStyles } from "@material-ui/core";
+import React, { useEffect, useState } from "react";
+import { SyncCustomAction } from "../../../../domain/entities/actions/SyncCustomAction";
+import { DataMart } from "../../../../domain/entities/xmart/DataMart";
+import i18n from "../../../../locales";
+import { useAppContext } from "../../../contexts/app-context";
+import { CustomActionWizardStepProps } from "../CustomActionWizard";
+
+const LiEntry: React.FC<{ label: string; value?: string }> = ({ label, value, children }) => {
+    return (
+        <li key={label}>
+            {label}
+            {value || children ? ": " : ""}
+            {value}
+            {children}
+        </li>
+    );
+};
+
+const useStyles = makeStyles({
+    saveButton: {
+        margin: 10,
+        backgroundColor: "#2b98f0",
+        color: "white",
+    },
+    buttonContainer: {
+        display: "flex",
+        justifyContent: "space-between",
+    },
+});
+
+export const SummaryStep = ({ action, onCancel }: CustomActionWizardStepProps) => {
+    const { compositionRoot } = useAppContext();
+    const snackbar = useSnackbar();
+    const classes = useStyles();
+    const loading = useLoading();
+
+    const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+
+    const openCancelDialog = () => setCancelDialogOpen(true);
+
+    const closeCancelDialog = () => setCancelDialogOpen(false);
+
+    const save = async () => {
+        const errors = action.validate().map(e => e.description);
+        if (errors.length > 0) {
+            snackbar.error(errors.join("\n"));
+        } else {
+            loading.show(true, i18n.t("Saving action..."));
+            compositionRoot.actions.save(action).run(
+                () => {
+                    onCancel();
+                    loading.reset();
+                },
+                error => {
+                    snackbar.error(error);
+                    loading.reset();
+                }
+            );
+        }
+    };
+
+    return (
+        <React.Fragment>
+            <ConfirmationDialog
+                isOpen={cancelDialogOpen}
+                onSave={onCancel}
+                onCancel={closeCancelDialog}
+                title={i18n.t("Cancel action wizard")}
+                description={i18n.t(
+                    "You are about to exit the Action Creation Wizard. All your changes will be lost. Are you sure you want to proceed?"
+                )}
+                saveText={i18n.t("Yes")}
+            />
+
+            <SummaryStepContent action={action} />
+
+            <div className={classes.buttonContainer}>
+                <div>
+                    <Button onClick={openCancelDialog} variant="contained">
+                        {i18n.t("Cancel")}
+                    </Button>
+
+                    <Button className={classes.saveButton} onClick={save} variant="contained">
+                        {i18n.t("Save")}
+                    </Button>
+                </div>
+            </div>
+        </React.Fragment>
+    );
+};
+
+interface SummaryStepContentProps {
+    action: SyncCustomAction;
+}
+
+const SummaryStepContent: React.FC<SummaryStepContentProps> = ({ action }) => {
+    const { compositionRoot } = useAppContext();
+    const snackbar = useSnackbar();
+    const [connection, setConnection] = useState<DataMart>();
+
+    useEffect(() => {
+        compositionRoot.connection.listAll().run(
+            dataMarts => {
+                const connection = dataMarts.find(d => d.id === action.connectionId);
+                setConnection(connection);
+            },
+            error => snackbar.error(error)
+        );
+    }, [compositionRoot, snackbar, action]);
+
+    return (
+        <ul>
+            <LiEntry label={i18n.t("Name")} value={action.name} />
+
+            <LiEntry label={i18n.t("Connection")} value={connection?.name} />
+
+            {action.description && <LiEntry label={i18n.t("Description")} value={action.description} /> }
+
+            <LiEntry label={i18n.t("Custom Code")} value={action.customCode} />
+        </ul>
+    );
+};

--- a/src/webapp/pages/Router.tsx
+++ b/src/webapp/pages/Router.tsx
@@ -22,7 +22,7 @@ export const Router = () => {
     return (
         <HashRouter>
             <Routes>
-            <Route
+                <Route
                     path="/actions/new/custom"
                     element={
                         <RouterPage title={i18n.t("Custom Action")} parentRoute="/actions">

--- a/src/webapp/pages/Router.tsx
+++ b/src/webapp/pages/Router.tsx
@@ -22,6 +22,14 @@ export const Router = () => {
     return (
         <HashRouter>
             <Routes>
+            <Route
+                    path="/actions/new/custom"
+                    element={
+                        <RouterPage title={i18n.t("Custom Action")} parentRoute="/actions">
+                            <ActionDetailPage action="custom" />
+                        </RouterPage>
+                    }
+                />
                 <Route
                     path="/actions/new"
                     element={

--- a/src/webapp/pages/action-detail/ActionDetailPage.tsx
+++ b/src/webapp/pages/action-detail/ActionDetailPage.tsx
@@ -2,8 +2,12 @@ import { useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { SyncAction } from "../../../domain/entities/actions/SyncAction";
+import { SyncCustomAction } from "../../../domain/entities/actions/SyncCustomAction";
+
 import i18n from "../../../locales";
 import ActionWizard from "../../components/action-wizard/ActionWizard";
+import CustomActionWizard from "../../components/custom-action-wizard/CustomActionWizard";
+
 import { useAppContext } from "../../contexts/app-context";
 
 //TODO: implement confirmation dialog to back or cancel in the RouterPage
@@ -16,7 +20,8 @@ export const ActionDetailPage: React.FC<ActionDetailPageProps> = ({ action }) =>
 
     const { id } = useParams();
 
-    const [syncAction, updateSyncAction] = useState(() => SyncAction.build());
+    const [syncAction, updateSyncAction] = useState<SyncAction>(SyncAction.build());
+    const [syncCustomAction, updateSyncCustomAction] = useState<SyncCustomAction>(SyncCustomAction.build());
 
     useEffect(() => {
         if (action === "edit" && !!id) {
@@ -24,7 +29,10 @@ export const ActionDetailPage: React.FC<ActionDetailPageProps> = ({ action }) =>
 
             compositionRoot.actions.get(id).run(
                 action => {
-                    updateSyncAction(action ?? SyncAction.build());
+                    if(action && action.type === "custom") {
+                        updateSyncCustomAction(SyncCustomAction.build(action));
+                    }
+                    else updateSyncAction(action ?? SyncAction.build(action));
                     loading.reset();
                 },
                 () => {
@@ -37,11 +45,15 @@ export const ActionDetailPage: React.FC<ActionDetailPageProps> = ({ action }) =>
 
     return (
         <React.Fragment>
-            <ActionWizard action={syncAction} onChange={updateSyncAction} onCancel={() => navigate("/actions")} />
+            {action === "custom" || (action === "edit" && syncCustomAction.connectionId !== "")
+            ? <CustomActionWizard action={syncCustomAction} onChange={updateSyncCustomAction} onCancel={() => navigate("/actions")} />
+            : <ActionWizard action={syncAction} onChange={updateSyncAction} onCancel={() => navigate("/actions")} />
+
+            }
         </React.Fragment>
     );
 };
 
 export interface ActionDetailPageProps {
-    action: "edit" | "new";
+    action: "edit" | "new" | "custom";
 }

--- a/src/webapp/pages/action-detail/ActionDetailPage.tsx
+++ b/src/webapp/pages/action-detail/ActionDetailPage.tsx
@@ -29,10 +29,9 @@ export const ActionDetailPage: React.FC<ActionDetailPageProps> = ({ action }) =>
 
             compositionRoot.actions.get(id).run(
                 action => {
-                    if(action && action.type === "custom") {
-                        updateSyncCustomAction(SyncCustomAction.build(action));
-                    }
-                    else updateSyncAction(action ?? SyncAction.build(action));
+                    if (action && action.type === "custom") {
+updateSyncCustomAction(SyncCustomAction.build(action));
+                    } else updateSyncAction(action ?? SyncAction.build(action));
                     loading.reset();
                 },
                 () => {
@@ -45,11 +44,15 @@ export const ActionDetailPage: React.FC<ActionDetailPageProps> = ({ action }) =>
 
     return (
         <React.Fragment>
-            {action === "custom" || (action === "edit" && syncCustomAction.connectionId !== "")
-            ? <CustomActionWizard action={syncCustomAction} onChange={updateSyncCustomAction} onCancel={() => navigate("/actions")} />
-            : <ActionWizard action={syncAction} onChange={updateSyncAction} onCancel={() => navigate("/actions")} />
-
-            }
+            {action === "custom" || (action === "edit" && syncCustomAction.connectionId !== "") ? (
+                <CustomActionWizard
+                    action={syncCustomAction}
+                    onChange={updateSyncCustomAction}
+                    onCancel={() => navigate("/actions")}
+                />
+            ) : (
+                <ActionWizard action={syncAction} onChange={updateSyncAction} onCancel={() => navigate("/actions")} />
+            )}
         </React.Fragment>
     );
 };

--- a/src/webapp/pages/actions-list/ActionsListPage.tsx
+++ b/src/webapp/pages/actions-list/ActionsListPage.tsx
@@ -45,6 +45,8 @@ export const ActionsListPage: React.FC = () => {
         () => [
             { name: "name", text: i18n.t("Name") },
             { name: "description", text: i18n.t("Description") },
+            { name: "type", text: i18n.t("Type") },
+
         ],
         []
     );
@@ -52,6 +54,8 @@ export const ActionsListPage: React.FC = () => {
     const details: ObjectsTableDetailField<SyncAction>[] = [
         { name: "name", text: i18n.t("Name") },
         { name: "description", text: i18n.t("Description") },
+        { name: "type", text: i18n.t("Type") },
+
     ];
 
     const goToCreateAction = useCallback(() => {
@@ -184,14 +188,14 @@ export const ActionsListPage: React.FC = () => {
                     title={i18n.t("Choose action type")}
                     disableSave={true}
                 >
-                    <DialogContent style={{display: "flex", flexDirection: "column"}}>
-                    <Button type="reset" onClick={goToCreateAction} primary={true}>
-                        {i18n.t("Standard action")}
-                    </Button>
-                    <br/>
-                    <Button type="reset" onClick={goToCreateCustomAction} primary={true}>
-                        {i18n.t("Custom action")}
-                    </Button>
+                    <DialogContent style={{ display: "flex", flexDirection: "column" }}>
+                        <Button type="reset" onClick={goToCreateAction} primary={true}>
+                            {i18n.t("Standard action")}
+                        </Button>
+                        <br />
+                        <Button type="reset" onClick={goToCreateCustomAction} primary={true}>
+                            {i18n.t("Custom action")}
+                        </Button>
                     </DialogContent>
                 </ConfirmationDialog>
             )}

--- a/src/webapp/pages/actions-list/ActionsListPage.tsx
+++ b/src/webapp/pages/actions-list/ActionsListPage.tsx
@@ -10,7 +10,8 @@ import {
     useLoading,
     useSnackbar,
 } from "@eyeseetea/d2-ui-components";
-import { Icon } from "@material-ui/core";
+import { Button } from "@dhis2/ui";
+import { Icon, DialogContent } from "@material-ui/core";
 import _ from "lodash";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -31,6 +32,7 @@ export const ActionsListPage: React.FC = () => {
     const [selection, updateSelection] = useState<TableSelection[]>([]);
     const [toDelete, setToDelete] = useState<string[]>([]);
     const [results, setResults] = useState<SyncResult[]>();
+    const [openActionOptions, setOpenActionOptions] = useState<boolean>(false);
 
     useEffect(() => {
         compositionRoot.actions.list().run(
@@ -54,6 +56,10 @@ export const ActionsListPage: React.FC = () => {
 
     const goToCreateAction = useCallback(() => {
         navigate("/actions/new");
+    }, [navigate]);
+
+    const goToCreateCustomAction = useCallback(() => {
+        navigate("/actions/new/custom");
     }, [navigate]);
 
     const goToEditAction = useCallback(
@@ -171,6 +177,25 @@ export const ActionsListPage: React.FC = () => {
                 />
             )}
 
+            {openActionOptions && (
+                <ConfirmationDialog
+                    isOpen={true}
+                    onCancel={() => setOpenActionOptions(false)}
+                    title={i18n.t("Choose action type")}
+                    disableSave={true}
+                >
+                    <DialogContent style={{display: "flex", flexDirection: "column"}}>
+                    <Button type="reset" onClick={goToCreateAction} primary={true}>
+                        {i18n.t("Standard action")}
+                    </Button>
+                    <br/>
+                    <Button type="reset" onClick={goToCreateCustomAction} primary={true}>
+                        {i18n.t("Custom action")}
+                    </Button>
+                    </DialogContent>
+                </ConfirmationDialog>
+            )}
+
             <ObjectsTable<SyncAction>
                 rows={rows}
                 columns={columns}
@@ -178,7 +203,7 @@ export const ActionsListPage: React.FC = () => {
                 selection={selection}
                 actions={actions}
                 onChange={handleTableChange}
-                onActionButtonClick={goToCreateAction}
+                onActionButtonClick={() => setOpenActionOptions(true)}
             />
         </React.Fragment>
     );


### PR DESCRIPTION
### :pushpin: References

 **Issue:** Closes [Add custom actions to the new action wizard](https://app.clickup.com/t/1p2j01a)

### :memo: Implementation
- Modal pops up when you click on add a new action to choose a standard or custom action
- Added a new property "type" to differentiate between custom and standard
- Created new Wizard for custom actions which only have general info, custom code and summary steps 
- I added the type as a new column in the list actions page

### :art: Screenshots
<img width="940" alt="Screen Shot 2021-12-18 at 11 06 01 PM" src="https://user-images.githubusercontent.com/20975863/146656694-b17d4839-f6ab-4fe2-a03a-86f6107a6c7b.png">
<img width="932" alt="Screen Shot 2021-12-18 at 11 01 24 PM" src="https://user-images.githubusercontent.com/20975863/146656696-a1485053-20c4-478c-9c6b-e4eac725ad65.png">
<img width="950" alt="Screen Shot 2021-12-18 at 11 01 17 PM" src="https://user-images.githubusercontent.com/20975863/146656697-50d5d36e-7881-4b0a-bc88-e52be6d48329.png">


### :fire: Testing
