### PR TITLE
[Fix] Prevent action from saving if user is not logged in (4)

### DIFF
--- a/src/webapp/components/action-wizard/steps/SummaryStep.tsx
+++ b/src/webapp/components/action-wizard/steps/SummaryStep.tsx
@@ -36,11 +36,10 @@ const useStyles = makeStyles({
 });
 
 export const SummaryStep = ({ action, onCancel }: ActionWizardStepProps) => {
-    const { compositionRoot } = useAppContext();
+    const { compositionRoot, azureInstance } = useAppContext();
     const snackbar = useSnackbar();
     const classes = useStyles();
     const loading = useLoading();
-
     const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
 
     const openCancelDialog = () => setCancelDialogOpen(true);
@@ -49,6 +48,11 @@ export const SummaryStep = ({ action, onCancel }: ActionWizardStepProps) => {
 
     const save = async () => {
         const errors = action.validate().map(e => e.description);
+        const [account] = azureInstance.getAllAccounts();
+
+        if (!account) {
+            errors.push("The user is not logged in");
+        }
         if (errors.length > 0) {
             snackbar.error(errors.join("\n"));
         } else {

--- a/src/webapp/components/action-wizard/steps/SummaryStep.tsx
+++ b/src/webapp/components/action-wizard/steps/SummaryStep.tsx
@@ -47,12 +47,9 @@ export const SummaryStep = ({ action, onCancel }: ActionWizardStepProps) => {
     const closeCancelDialog = () => setCancelDialogOpen(false);
 
     const save = async () => {
-        const errors = action.validate().map(e => e.description);
         const [account] = azureInstance.getAllAccounts();
-
-        if (!account) {
-            errors.push("The user is not logged in");
-        }
+        const validationErrors = action.validate().map(e => e.description);
+        const errors = _.compact([...validationErrors, !account ? "The user is not logged in" : undefined]);
         if (errors.length > 0) {
             snackbar.error(errors.join("\n"));
         } else {


### PR DESCRIPTION
### :pushpin: References

 **Issue:** Closes [Actions are saved even if there're errors (try without login)](https://app.clickup.com/t/1p84r56)

### :memo: Implementation
- If the user is not logged in then I push an error 
- The other possibilities for data input errors were tested and they did not save the action so they worked as needed. I tested not adding the modelMappings which returned an error and did not save. The frontend validation catches all null input.

### :art: Screenshots
<img width="899" alt="Screen Shot 2021-12-26 at 9 22 02 PM" src="https://user-images.githubusercontent.com/20975863/147419221-43534b39-c102-4e36-a736-4bb1c2d0a378.png">



### :fire: Testing
